### PR TITLE
Refine PID graph UI and use FreeRTOS for display

### DIFF
--- a/include/display.h
+++ b/include/display.h
@@ -39,7 +39,8 @@ void drawMotionJoystickPose();
 void drawPeripheralJoystickPose();
 void drawDrongazInterface();
 void drawTelemetryInfo();
-void drawPidGraphs();
+// Draw a single PID graph based on the currently selected axis
+void drawPidGraph();
 void drawOrientationCube();
 void drawPairingMenu();
 void drawHomeMenu();
@@ -49,3 +50,9 @@ void Line_detection();
 void Pid_Tuner();
 void Fire_detection();
 void displayMenu();
+
+// Utility helpers
+void drawHeader(const char* title);
+
+// Currently selected PID graph index (0=pitch,1=roll,2=yaw)
+extern int pidGraphIndex;


### PR DESCRIPTION
## Summary
- Add reusable `drawHeader` for consistent screen headers
- Show one PID graph at a time with encoder scrolling between axes
- Move OLED rendering to a FreeRTOS task for smoother updates

## Testing
- `pio run` *(fails: command not found)*
- `pip install platformio` *(fails: proxy 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68b08fa9f2c4832a83c1b116f32f29b0