### PR TITLE
Restore soft AP WiFi configuration for OTA

### DIFF
--- a/include/espnow_discovery.h
+++ b/include/espnow_discovery.h
@@ -9,8 +9,8 @@
 // message and pairs with any responding peers.
 class EspNowDiscovery {
 public:
-    // Ensure WiFi is in STA mode; ESP-NOW should already be initialised
-    // by the caller.
+    // Ensure WiFi remains in AP+STA mode so OTA soft AP stays available;
+    // ESP-NOW should already be initialised by the caller.
     void begin();
     // Broadcast a discovery message to any nearby devices.
     void discover();

--- a/src/espnow_discovery.cpp
+++ b/src/espnow_discovery.cpp
@@ -9,8 +9,8 @@ struct DiscoveryMessage {
 };
 
 void EspNowDiscovery::begin() {
-    // Ensure we're in station mode so broadcasts are received.
-    WiFi.mode(WIFI_STA);
+    // Ensure station + AP mode so OTA soft AP remains active.
+    WiFi.mode(WIFI_AP_STA);
     // Record any existing peers (e.g. pre-configured target).
     esp_now_peer_num_t count{};
     if (esp_now_get_peer_num(&count) == ESP_OK) {


### PR DESCRIPTION
## Summary
- keep discovery in AP+STA mode so OTA soft AP stays active
- update discovery header comment to document AP+STA requirement

## Testing
- `pio run` *(fails: command not found)*
- `pip install platformio` *(fails: ProxyError - Tunnel connection failed: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68b0934063d8832aa0424deeee96ae7b