### PR TITLE
Ensure Soft AP persists after ESP-NOW discovery

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -325,6 +325,8 @@ void setup() {
   oled.sendBuffer();
   delay(1000);debug("Coms in place\n\n")
   discovery.begin();
+  // Re-enable Soft AP in case discovery initialization resets WiFi.
+  WiFi.softAP(ssid, password);
   discovery.discover();
   //==================================
 


### PR DESCRIPTION
## Summary
- Re-enable the "ILITE PORT" Soft AP after initializing ESP-NOW discovery to prevent it from disappearing.

## Testing
- `platformio run` (command not found: platformio)
- `pip install platformio` (failed: Could not connect to proxy: 403 Forbidden)


------
https://chatgpt.com/codex/tasks/task_e_68b098e71c80832ab80b49625789441f