### PR TITLE
Improve telemetry screen and graph refresh

### DIFF
--- a/include/telemetry.h
+++ b/include/telemetry.h
@@ -36,3 +36,4 @@ extern telemetryPacket telemetry;
 extern int16_t pidPitchHistory[screen_Width];
 extern int16_t pidRollHistory[screen_Width];
 extern int16_t pidYawHistory[screen_Width];
+void appendPidSample();

--- a/src/display.cpp
+++ b/src/display.cpp
@@ -211,11 +211,16 @@ void drawTelemetryInfo(){
   oled.clearBuffer();
   drawHeader("Telemetry");
   oled.setFont(textFont);
-  oled.setCursor(0,22);  oled.print("Alt:");  oled.print(telemetry.altitude);
-  oled.setCursor(0,37);  oled.print("P:");    oled.print(telemetry.pitch);
-  oled.setCursor(64,37); oled.print("R:");    oled.print(telemetry.roll);
-  oled.setCursor(0,52);  oled.print("Y:");    oled.print(telemetry.yaw);
-  oled.setCursor(64,52); oled.print("Acc:");  oled.print(telemetry.accelZ);
+  int y = 22;
+  oled.setCursor(0, y);       oled.print("Alt: ");  oled.print(telemetry.altitude);
+  y += 10;
+  oled.setCursor(0, y);       oled.print("Pitch: "); oled.print(telemetry.pitch);
+  y += 10;
+  oled.setCursor(0, y);       oled.print("Roll: ");  oled.print(telemetry.roll);
+  y += 10;
+  oled.setCursor(0, y);       oled.print("Yaw: ");   oled.print(telemetry.yaw);
+  y += 10;
+  oled.setCursor(0, y);       oled.print("AccZ: ");  oled.print(telemetry.accelZ);
   oled.setFont(iconFont);
   oled.setCursor(112,22);
   if(discovery.hasPeers()){

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -113,14 +113,6 @@ void OnDataRecv(const uint8_t * mac, const uint8_t *incomingData, int len) {
   // send a telemetryPacket structure defined above.
   memcpy(&telemetry, incomingData, sizeof(telemetry));
 
-  // Update PID history buffers for the graphing screen. The oldest sample is
-  // discarded and the newest sample appended to the end of each buffer.
-  memmove(pidPitchHistory, pidPitchHistory + 1, (screen_Width - 1) * sizeof(int16_t));
-  memmove(pidRollHistory,  pidRollHistory  + 1, (screen_Width - 1) * sizeof(int16_t));
-  memmove(pidYawHistory,   pidYawHistory   + 1, (screen_Width - 1) * sizeof(int16_t));
-  pidPitchHistory[screen_Width - 1] = telemetry.pidPitch;
-  pidRollHistory[screen_Width - 1]  = telemetry.pidRoll;
-  pidYawHistory[screen_Width - 1]   = telemetry.pidYaw;
 }
 
  
@@ -247,7 +239,8 @@ void displayTask(void* pvParameters){
       case 3: drawOrientationCube(); break;
       case 4: drawPairingMenu(); break;
     }
-    vTaskDelay(50 / portTICK_PERIOD_MS);
+    appendPidSample();
+    vTaskDelay(10 / portTICK_PERIOD_MS);
   }
 }
 

--- a/src/telemetry.cpp
+++ b/src/telemetry.cpp
@@ -1,4 +1,5 @@
 #include "telemetry.h"
+#include <string.h>
 
 emissionDataPacket emission{};
 receptionDataPacket reception{};
@@ -6,3 +7,12 @@ telemetryPacket telemetry{};
 int16_t pidPitchHistory[screen_Width];
 int16_t pidRollHistory[screen_Width];
 int16_t pidYawHistory[screen_Width];
+
+void appendPidSample() {
+  memmove(pidPitchHistory, pidPitchHistory + 1, (screen_Width - 1) * sizeof(int16_t));
+  memmove(pidRollHistory,  pidRollHistory  + 1, (screen_Width - 1) * sizeof(int16_t));
+  memmove(pidYawHistory,   pidYawHistory   + 1, (screen_Width - 1) * sizeof(int16_t));
+  pidPitchHistory[screen_Width - 1] = telemetry.pidPitch;
+  pidRollHistory[screen_Width - 1]  = telemetry.pidRoll;
+  pidYawHistory[screen_Width - 1]   = telemetry.pidYaw;
+}


### PR DESCRIPTION
## Summary
- Reorganize telemetry screen layout for clearer data display
- Maintain PID history at fixed 100 Hz for smoother graphs
- Refresh display at 100 Hz without impacting WiFi handling

## Testing
- ⚠️ `pio run` *(missing `platformio` and network access blocked)*

------
https://chatgpt.com/codex/tasks/task_e_68b0b1853220832aa0af1b3790941c3e