### PR TITLE
Implement handshake-based ESP-NOW discovery

### DIFF
--- a/include/espnow_discovery.h
+++ b/include/espnow_discovery.h
@@ -14,9 +14,10 @@ public:
     void begin();
     // Broadcast a discovery message to any nearby devices.
     void discover();
-    // Examine an incoming packet and, if the sender isn't already paired,
-    // add it as a new peer.
-    void handleIncoming(const uint8_t *mac, const uint8_t *incomingData, int len);
+    // Examine an incoming packet and, if it is part of the discovery
+    // handshake, process it. Returns true if the packet was consumed by the
+    // discovery system and should not be treated as application data.
+    bool handleIncoming(const uint8_t *mac, const uint8_t *incomingData, int len);
     // Return true if at least one peer has been paired.
     bool hasPeers() const;
     // Retrieve the number of paired peers.
@@ -27,7 +28,8 @@ public:
 private:
     static constexpr int kMaxPeers = 5;
     uint8_t peerMacs[kMaxPeers][6] = {};
-    int peerCount = 0;
+    bool    peerAcked[kMaxPeers] = {};
+    int     peerCount = 0;
 };
 
 #endif // ESPNOW_DISCOVERY_H

--- a/src/espnow_discovery.cpp
+++ b/src/espnow_discovery.cpp
@@ -3,9 +3,35 @@
 // Broadcast MAC address used for discovery messages.
 static const uint8_t kBroadcastMac[] = {0xff, 0xff, 0xff, 0xff, 0xff, 0xff};
 
-// Simple discovery payload. More fields can be added in the future.
-struct DiscoveryMessage {
-    uint8_t type = 0x01;
+// Message type identifiers for the discovery handshake.
+enum MessageType : uint8_t {
+    kScan       = 0x01, // ILITE broadcast
+    kResponse   = 0x02, // Device responds with its type + MAC
+    kAck        = 0x03, // ILITE acknowledges and shares its MAC
+    kAckConfirm = 0x04  // Device confirms receipt of ILITE MAC
+};
+
+// Broadcast scan message with only a type field.
+struct ScanMessage {
+    uint8_t type = kScan;
+};
+
+// Device response: includes its device type and MAC address.
+struct ResponseMessage {
+    uint8_t type      = kResponse;
+    uint8_t deviceType;
+    uint8_t mac[6];
+};
+
+// Acknowledgement from ILITE containing its MAC address.
+struct AckMessage {
+    uint8_t type = kAck;
+    uint8_t mac[6];
+};
+
+// Confirmation message from the device after receiving ILITE's MAC.
+struct AckConfirmMessage {
+    uint8_t type = kAckConfirm;
 };
 
 void EspNowDiscovery::begin() {
@@ -18,40 +44,66 @@ void EspNowDiscovery::begin() {
 }
 
 void EspNowDiscovery::discover() {
-    DiscoveryMessage msg;
+    ScanMessage msg;
     esp_now_send(kBroadcastMac, reinterpret_cast<const uint8_t*>(&msg), sizeof(msg));
 }
 
-void EspNowDiscovery::handleIncoming(const uint8_t *mac, const uint8_t *incomingData, int len) {
-    if (len < sizeof(DiscoveryMessage)) {
-        return; // Ignore unknown packets
+bool EspNowDiscovery::handleIncoming(const uint8_t *mac, const uint8_t *incomingData, int len) {
+    if (len < 1) {
+        return false; // Not a discovery message
     }
 
-    // Pair with the device if not already paired.
-    if (!esp_now_is_peer_exist(mac)) {
-        esp_now_peer_info_t peerInfo{};
-        memcpy(peerInfo.peer_addr, mac, 6);
-        peerInfo.channel = 0; // current channel
-        peerInfo.encrypt = false;
-        if (esp_now_add_peer(&peerInfo) == ESP_OK) {
-            Serial.print("Paired with: ");
-            Serial.printf("%02X:%02X:%02X:%02X:%02X:%02X\n", mac[0], mac[1], mac[2], mac[3], mac[4], mac[5]);
-            // Remember this peer for UI display.
-            bool known = false;
-            for (int i = 0; i < peerCount; ++i) {
-                if (memcmp(peerMacs[i], mac, 6) == 0) {
-                    known = true;
-                    break;
+    uint8_t msgType = incomingData[0];
+    if (msgType == kResponse) {
+        if (len < static_cast<int>(sizeof(ResponseMessage))) {
+            return true; // Malformed but consumed
+        }
+        const ResponseMessage* resp = reinterpret_cast<const ResponseMessage*>(incomingData);
+        // Pair with the device if not already paired.
+        if (!esp_now_is_peer_exist(mac)) {
+            esp_now_peer_info_t peerInfo{};
+            memcpy(peerInfo.peer_addr, mac, 6);
+            peerInfo.channel = 0; // current channel
+            peerInfo.encrypt = false;
+            if (esp_now_add_peer(&peerInfo) == ESP_OK) {
+                Serial.print("Paired with: ");
+                Serial.printf("%02X:%02X:%02X:%02X:%02X:%02X\n", mac[0], mac[1], mac[2], mac[3], mac[4], mac[5]);
+                // Remember this peer for UI display.
+                bool known = false;
+                for (int i = 0; i < peerCount; ++i) {
+                    if (memcmp(peerMacs[i], mac, 6) == 0) {
+                        known = true;
+                        break;
+                    }
+                }
+                if (!known && peerCount < kMaxPeers) {
+                    memcpy(peerMacs[peerCount], mac, 6);
+                    peerAcked[peerCount] = false;
+                    peerCount++;
                 }
             }
-            if (!known && peerCount < kMaxPeers) {
-                memcpy(peerMacs[peerCount], mac, 6);
-                peerCount++;
+        }
+
+        // Send acknowledgement with our MAC address.
+        AckMessage ack;
+        WiFi.macAddress(ack.mac);
+        esp_now_send(mac, reinterpret_cast<uint8_t*>(&ack), sizeof(ack));
+        return true;
+    } else if (msgType == kAckConfirm) {
+        // Device confirms receipt of our MAC.
+        for (int i = 0; i < peerCount; ++i) {
+            if (memcmp(peerMacs[i], mac, 6) == 0) {
+                peerAcked[i] = true;
+                break;
             }
         }
+        return true;
     }
+
+    return false; // Not a discovery message
 }
 
 bool EspNowDiscovery::hasPeers() const {
     return peerCount > 0;
 }
+

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -102,11 +102,11 @@ void OnDataSent(const uint8_t *mac_addr, esp_now_send_status_t status)
 }
 
 void OnDataRecv(const uint8_t * mac, const uint8_t *incomingData, int len) {
-  // If this is a new device, pair with it and remember its address.
-  bool isNewPeer = !esp_now_is_peer_exist(mac);
-  discovery.handleIncoming(mac, incomingData, len);
-  if (isNewPeer) {
+  // Let the discovery helper consume any handshake packets.
+  if (discovery.handleIncoming(mac, incomingData, len)) {
+    // Remember the sender as the current target once paired.
     memcpy(targetAddress, mac, 6);
+    return;
   }
 
   // Copy telemetry data from the incoming packet. The drone is expected to


### PR DESCRIPTION
## Summary
- Replace simple discovery with explicit handshake exchanging device type and MAC addresses
- Handle discovery packets before telemetry and track peers with acknowledgement state

## Testing
- `platformio run` *(fails: command not found / platformio not installed)*


------
https://chatgpt.com/codex/tasks/task_e_68b0efa4a340832aaf7655c7ec9744e5