### PR TITLE
Add dashboard navigation and serial debug output

### DIFF
--- a/src/display.cpp
+++ b/src/display.cpp
@@ -333,8 +333,8 @@ void drawHomeMenu(){
   oled.clearBuffer();
   drawHeader("Menu");
   oled.setFont(textFont);
-  const char* items[] = {"Telemetry","PID Graph","Orientation","Pairing","About"};
-  for(int i=0;i<5;i++){
+  const char* items[] = {"Dashboard","Telemetry","PID Graph","Orientation","Pairing","About"};
+  for(int i=0;i<6;i++){
     oled.setCursor(0,22 + i*10);
     if(i==homeMenuIndex) oled.print(">"); else oled.print(" ");
     oled.print(items[i]);

--- a/src/espnow_discovery.cpp
+++ b/src/espnow_discovery.cpp
@@ -31,6 +31,7 @@ void EspNowDiscovery::begin() {
 void EspNowDiscovery::discover() {
     IdentityMessage msg{};
     msg.type = SCAN_REQUEST;
+    Serial.println("Sending discovery request");
     esp_now_send(kBroadcastMac, reinterpret_cast<const uint8_t*>(&msg), sizeof(msg));
 }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -97,13 +97,17 @@ int16_t yawCommand     = 0;
 //Coms Fcns
 void OnDataSent(const uint8_t *mac_addr, esp_now_send_status_t status)
 {
-  // Serial.print("\r\nLast Packet Send Status:\t");
-  // Serial.println(status == ESP_NOW_SEND_SUCCESS ? "Delivery Success" : "Delivery Fail");
+  debug("Last Packet Send Status: ");
+  debug(status == ESP_NOW_SEND_SUCCESS ? "Delivery Success\n" : "Delivery Fail\n");
 }
 
 void OnDataRecv(const uint8_t * mac, const uint8_t *incomingData, int len) {
+  debug("Data received: ");
+  debug(len);
+  debug(" bytes\n");
   // Let the discovery helper consume any handshake packets.
   if (discovery.handleIncoming(mac, incomingData, len)) {
+    debug("Discovery handshake\n");
     // Remember the sender as the current target once paired.
     memcpy(targetAddress, mac, 6);
     return;
@@ -430,7 +434,7 @@ void loop() {
   // Handle encoder rotation depending on the current page.
   if(displayMode == 0){
     int delta = encoderCount - lastEncoderCount;
-    int menuCount = 5;
+    int menuCount = 6;
     if(delta != 0){
       homeMenuIndex = (homeMenuIndex + delta) % menuCount;
       if(homeMenuIndex < 0) homeMenuIndex += menuCount;
@@ -471,11 +475,12 @@ void loop() {
       lastEncoderCount = encoderCount;
     } else if(displayMode == 0){
       switch(homeMenuIndex){
-        case 0: displayMode = 1; break;
-        case 1: displayMode = 2; break;
-        case 2: displayMode = 3; break;
-        case 3: displayMode = 4; selectedPeer = 0; break;
-        case 4: displayMode = 6; break;
+        case 0: displayMode = 5; break; // Dashboard
+        case 1: displayMode = 1; break; // Telemetry
+        case 2: displayMode = 2; break; // PID Graph
+        case 3: displayMode = 3; break; // Orientation
+        case 4: displayMode = 4; selectedPeer = 0; break; // Pairing
+        case 5: displayMode = 6; break; // About
       }
       lastEncoderCount = encoderCount;
       homeSelected = false;
@@ -492,7 +497,7 @@ void loop() {
       }
     } else if(displayMode == 2){
       displayMode = 0;
-      homeMenuIndex = 1;
+      homeMenuIndex = 2;
       lastEncoderCount = encoderCount;
     } else {
       if(homeSelected){
@@ -531,5 +536,9 @@ void loop() {
   if(esp_now_send(targetAddress, (uint8_t *) &emission, sizeof(emission))==ESP_OK)
   {
     sent_Status=1;
-  }else{sent_Status=0;}
+    debug("Send ok\n");
+  }else{
+    sent_Status=0;
+    debug("Send failed\n");
+  }
 }


### PR DESCRIPTION
## Summary
- Add dashboard entry to home menu and update navigation logic
- Add serial debug prints for ESP-NOW send/receive and discovery

## Testing
- `pip install platformio` *(fails: Cannot connect to proxy)*
- `pio run` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b1a3f46e54832a854616c13f1e7e2f