### PR TITLE
Prioritize ESP-NOW communications

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -38,6 +38,7 @@ EspNowDiscovery discovery;
 xTaskHandle joystickPollTask = NULL;
 xTimerHandle encoderActionPollTimer = NULL;
 xTaskHandle displayEngine = NULL;
+xTaskHandle commsEngine = NULL;
 
 bool isbeeping=1;
 
@@ -250,6 +251,18 @@ void displayTask(void* pvParameters){
   }
 }
 
+void commTask(void* pvParameters){
+  const TickType_t delay = 20 / portTICK_PERIOD_MS; // 50Hz
+  for(;;){
+    if(esp_now_send(targetAddress, reinterpret_cast<uint8_t*>(&emission), sizeof(emission))==ESP_OK){
+      sent_Status = true;
+    }else{
+      sent_Status = false;
+    }
+    vTaskDelay(delay);
+  }
+}
+
 void setup() {
 
   //Pin directions ===================
@@ -327,6 +340,7 @@ void setup() {
   // Re-enable Soft AP in case discovery initialization resets WiFi.
   WiFi.softAP(ssid, password);
   discovery.discover();
+  xTaskCreatePinnedToCore(commTask, "comms", 4096, NULL, 3, &commsEngine, 0);
   //==================================
 
   //Interrupts handled in initInput()
@@ -531,14 +545,4 @@ void loop() {
   emission.arm_motors = btnmode;
 
   // Display rendering handled in FreeRTOS display task
-
-  // Send packet via ESP-NOW
-  if(esp_now_send(targetAddress, (uint8_t *) &emission, sizeof(emission))==ESP_OK)
-  {
-    sent_Status=1;
-    debug("Send ok\n");
-  }else{
-    sent_Status=0;
-    debug("Send failed\n");
-  }
 }


### PR DESCRIPTION
## Summary
- Add dedicated FreeRTOS task that transmits ESP-NOW packets at 50 Hz
- Launch high-priority comms task in setup to keep the link alive
- Simplify loop() to only populate command struct while comms task handles sending

## Testing
- `pip install --user platformio` *(failed: Tunnel connection failed: 403 Forbidden)*
- `pio run` *(command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b1b43c48c0832ab98e3af6f41d5aef