### PR TITLE
Improve orientation visualization and device pairing

### DIFF
--- a/include/display.h
+++ b/include/display.h
@@ -16,6 +16,8 @@ extern bool homeSelected;
 extern int selectedPeer;
 extern int lastEncoderCount;
 extern unsigned long lastDiscoveryTime;
+extern int infoPeer;
+extern bool pairedIsBulky;
 
 extern byte batteryLevel;
 extern byte Front_Distance;
@@ -43,6 +45,7 @@ void drawTelemetryInfo();
 void drawPidGraph();
 void drawOrientationCube();
 void drawPairingMenu();
+void drawPeerInfo();
 void drawHomeMenu();
 void drawHomeFooter();
 void drawDashboard();

--- a/include/espnow_discovery.h
+++ b/include/espnow_discovery.h
@@ -21,15 +21,18 @@ public:
     // Return true if at least one peer has been paired.
     bool hasPeers() const;
     // Retrieve the number of paired peers.
-    int  getPeerCount() const { return peerCount; }
-    // Get the MAC address of a paired peer by index.
-    const uint8_t* getPeer(int index) const { return peerMacs[index]; }
+      int  getPeerCount() const { return peerCount; }
+      // Get the MAC address of a paired peer by index.
+      const uint8_t* getPeer(int index) const { return peerMacs[index]; }
+      // Get the identity name of a paired peer by index.
+      const char* getPeerName(int index) const { return peerNames[index]; }
 
 private:
-    static constexpr int kMaxPeers = 5;
-    uint8_t peerMacs[kMaxPeers][6] = {};
-    bool    peerAcked[kMaxPeers] = {};
-    int     peerCount = 0;
-};
+      static constexpr int kMaxPeers = 5;
+      uint8_t peerMacs[kMaxPeers][6] = {};
+      bool    peerAcked[kMaxPeers] = {};
+      int     peerCount = 0;
+      char    peerNames[kMaxPeers][16] = {};
+  };
 
 #endif // ESPNOW_DISCOVERY_H

--- a/src/espnow_discovery.cpp
+++ b/src/espnow_discovery.cpp
@@ -55,12 +55,16 @@ bool EspNowDiscovery::handleIncoming(const uint8_t *mac, const uint8_t *incoming
                 for (int i = 0; i < peerCount; ++i) {
                     if (memcmp(peerMacs[i], mac, 6) == 0) {
                         known = true;
+                        strncpy(peerNames[i], msg->identity, sizeof(peerNames[i])-1);
+                        peerNames[i][sizeof(peerNames[i])-1] = '\0';
                         break;
                     }
                 }
                 if (!known && peerCount < kMaxPeers) {
                     memcpy(peerMacs[peerCount], mac, 6);
                     peerAcked[peerCount] = false;
+                    strncpy(peerNames[peerCount], msg->identity, sizeof(peerNames[peerCount])-1);
+                    peerNames[peerCount][sizeof(peerNames[peerCount])-1] = '\0';
                     peerCount++;
                 }
             }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -86,6 +86,8 @@ static esp_now_peer_info bot;
 
 static bool sent_Status;
 static bool receive_Status;
+unsigned long lastReceiveTime = 0;
+bool connected = false;
 
 
 
@@ -110,12 +112,16 @@ void OnDataRecv(const uint8_t * mac, const uint8_t *incomingData, int len) {
     debug("Discovery handshake\n");
     // Remember the sender as the current target once paired.
     memcpy(targetAddress, mac, 6);
+    lastReceiveTime = millis();
+    connected = true;
     return;
   }
 
   // Copy telemetry data from the incoming packet. The drone is expected to
   // send a TelemetryPacket structure defined above.
   memcpy(&telemetry, incomingData, sizeof(telemetry));
+  lastReceiveTime = millis();
+  connected = true;
 
 }
 
@@ -244,6 +250,7 @@ void displayTask(void* pvParameters){
       case 4: drawPairingMenu(); break;
       case 5: drawDashboard(); break;
       case 6: drawAbout(); break;
+      case 7: drawPeerInfo(); break;
     }
     appendPidSample();
     vTaskDelay(10 / portTICK_PERIOD_MS);
@@ -413,6 +420,15 @@ void loop() {
   // displayMenu();
   processComsData(0);
 
+  if(connected && millis() - lastReceiveTime > 3000){
+    connected = false;
+    displayMode = 4;
+    selectedPeer = 0;
+    discovery.discover();
+    lastDiscoveryTime = millis();
+    pairedIsBulky = false;
+  }
+
   if(millis()-lastBtnModeMillis >= 200)
   {
     if(!ispressed){
@@ -505,9 +521,23 @@ void loop() {
         homeSelected = false;
         lastEncoderCount = encoderCount;
       } else if(count > 0){
-        const uint8_t *mac = discovery.getPeer(selectedPeer);
-        memcpy(targetAddress, mac, 6);
+        infoPeer = selectedPeer;
+        displayMode = 7;
+        homeSelected = false;
+        lastEncoderCount = encoderCount;
       }
+    } else if(displayMode == 7){
+      if(homeSelected){
+        displayMode = 4;
+        homeSelected = false;
+      }else{
+        const uint8_t *mac = discovery.getPeer(infoPeer);
+        memcpy(targetAddress, mac, 6);
+        pairedIsBulky = strcmp(discovery.getPeerName(infoPeer), "Bulky") == 0;
+        displayMode = 5;
+        homeSelected = false;
+      }
+      lastEncoderCount = encoderCount;
     } else if(displayMode == 2){
       displayMode = 0;
       homeMenuIndex = 2;


### PR DESCRIPTION
## Summary
- Render drone orientation as a rectangular prism viewed from behind for clearer direction
- Store peer identity strings and show device names with detail screen and Bulky indicator
- Detect connection loss and return to pairing menu automatically

## Testing
- `pio test` *(fails: command not found)*
- `pip install platformio` *(fails: Tunnel connection failed: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68c6abfea7e0832aa95f4241732f1f14