### PR TITLE
Improve orientation visualization and device pairing

### DIFF
--- a/include/display.h
+++ b/include/display.h
@@ -16,6 +16,8 @@ extern bool homeSelected;
 extern int selectedPeer;
 extern int lastEncoderCount;
 extern unsigned long lastDiscoveryTime;
+extern int infoPeer;
+extern bool pairedIsBulky;
 
 extern byte batteryLevel;
 extern byte Front_Distance;
@@ -43,6 +45,7 @@ void drawTelemetryInfo();
 void drawPidGraph();
 void drawOrientationCube();
 void drawPairingMenu();
+void drawPeerInfo();
 void drawHomeMenu();
 void drawHomeFooter();
 void drawDashboard();

--- a/include/espnow_discovery.h
+++ b/include/espnow_discovery.h
@@ -21,15 +21,18 @@ public:
     // Return true if at least one peer has been paired.
     bool hasPeers() const;
     // Retrieve the number of paired peers.
-    int  getPeerCount() const { return peerCount; }
-    // Get the MAC address of a paired peer by index.
-    const uint8_t* getPeer(int index) const { return peerMacs[index]; }
+      int  getPeerCount() const { return peerCount; }
+      // Get the MAC address of a paired peer by index.
+      const uint8_t* getPeer(int index) const { return peerMacs[index]; }
+      // Get the identity name of a paired peer by index.
+      const char* getPeerName(int index) const { return peerNames[index]; }
 
 private:
-    static constexpr int kMaxPeers = 5;
-    uint8_t peerMacs[kMaxPeers][6] = {};
-    bool    peerAcked[kMaxPeers] = {};
-    int     peerCount = 0;
-};
+      static constexpr int kMaxPeers = 5;
+      uint8_t peerMacs[kMaxPeers][6] = {};
+      bool    peerAcked[kMaxPeers] = {};
+      int     peerCount = 0;
+      char    peerNames[kMaxPeers][16] = {};
+  };
 
 #endif // ESPNOW_DISCOVERY_H

--- a/src/espnow_discovery.cpp
+++ b/src/espnow_discovery.cpp
@@ -36,6 +36,19 @@ void EspNowDiscovery::discover() {
 }
 
 bool EspNowDiscovery::handleIncoming(const uint8_t *mac, const uint8_t *incomingData, int len) {
+    // Ignore any packets originating from the universal broadcast address
+    // or our own MAC address. The controller occasionally receives its own
+    // broadcast discovery frames and would otherwise attempt to treat them
+    // as peer telemetry or even pair with itself.
+    if (memcmp(mac, kBroadcastMac, 6) == 0) {
+        return false; // Ignore broadcast traffic
+    }
+    uint8_t selfMac[6];
+    WiFi.macAddress(selfMac);
+    if (memcmp(mac, selfMac, 6) == 0) {
+        return false; // Ignore packets we originated
+    }
+
     if (len != sizeof(IdentityMessage)) {
         return false; // Not a pairing message
     }
@@ -55,12 +68,16 @@ bool EspNowDiscovery::handleIncoming(const uint8_t *mac, const uint8_t *incoming
                 for (int i = 0; i < peerCount; ++i) {
                     if (memcmp(peerMacs[i], mac, 6) == 0) {
                         known = true;
+                        strncpy(peerNames[i], msg->identity, sizeof(peerNames[i])-1);
+                        peerNames[i][sizeof(peerNames[i])-1] = '\0';
                         break;
                     }
                 }
                 if (!known && peerCount < kMaxPeers) {
                     memcpy(peerMacs[peerCount], mac, 6);
                     peerAcked[peerCount] = false;
+                    strncpy(peerNames[peerCount], msg->identity, sizeof(peerNames[peerCount])-1);
+                    peerNames[peerCount][sizeof(peerNames[peerCount])-1] = '\0';
                     peerCount++;
                 }
             }


### PR DESCRIPTION
## Summary
- Render drone orientation as a rectangular prism viewed from behind for clearer direction
- Store peer identity strings and show device names with detail screen and Bulky indicator
- Detect connection loss and return to pairing menu automatically
- Ignore broadcast and self MAC frames to avoid self-pairing

## Testing
- `pio test` *(fails: command not found)*
- `pip install platformio` *(fails: Could not connect to proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68c6abfea7e0832aa95f4241732f1f14