### PR TITLE
Map centered throttle to minimum

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -561,8 +561,15 @@ void loop() {
   }
 
   // Populate packet with desired control values
-  // Throttle maps joystick position directly to RC range for Dronegaze.
-  emission.throttle = map(analogRead(joystickA_Y), 0, 4096, 1000, 2000);
+  // The throttle joystick is spring-centered, so treat the center position
+  // as minimum throttle and map only the upper half of its travel to the
+  // full RC range. Values below the center are clamped to 1000 μs.
+  int rawThrottle = analogRead(joystickA_Y);
+  if (rawThrottle <= 2048) {
+    emission.throttle = 1000;
+  } else {
+    emission.throttle = map(rawThrottle, 2048, 4095, 1000, 2000);
+  }
 
   // Yaw is controlled incrementally: joystick deflection adjusts the
   // accumulated yaw command rather than setting an absolute angle.


### PR DESCRIPTION
## Summary
- Treat centered throttle joystick as minimum and map only upper range to full RC throttle

## Testing
- `pio run` *(fails: command not found)*
- `pip install platformio` *(fails: Could not find a version that satisfies the requirement platformio)*

------
https://chatgpt.com/codex/tasks/task_e_68c6d15abef0832a880889dc96906a49