### PR TITLE
Implement ESP-NOW identity-based pairing workflow

### DIFF
--- a/include/espnow_discovery.h
+++ b/include/espnow_discovery.h
@@ -4,38 +4,119 @@
 #include <Arduino.h>
 #include <WiFi.h>
 #include <esp_now.h>
+#include <esp_wifi.h>
 
-// Simple ESP-NOW discovery helper that broadcasts a discovery
-// message and pairs with any responding peers.
+// -----------------------------------------------------------------------------
+// Compile-time configuration
+// -----------------------------------------------------------------------------
+
+#define DEVICE_ROLE_CONTROLLER 1
+#define DEVICE_ROLE_CONTROLLED 2
+
+#ifndef DEVICE_ROLE
+#define DEVICE_ROLE DEVICE_ROLE_CONTROLLER
+#endif
+
+#ifndef DEVICE_PLATFORM
+#define DEVICE_PLATFORM "ILITE"
+#endif
+
+#ifndef DEVICE_CUSTOM_ID
+#define DEVICE_CUSTOM_ID "ILITE-A10"
+#endif
+
+// ESP-NOW discovery and pairing parameters.
+static constexpr uint8_t WIFI_CHANNEL = 6;
+static constexpr uint32_t BROADCAST_INTERVAL_MS = 1000;
+static constexpr uint32_t DEVICE_TTL_MS = 10'000;
+static constexpr uint32_t LINK_TIMEOUT_MS = 5'000;
+
+// -----------------------------------------------------------------------------
+// Identity & packet layout
+// -----------------------------------------------------------------------------
+
+#pragma pack(push, 1)
+struct Identity {
+    char deviceType[12];
+    char platform[16];
+    char customId[32];
+    uint8_t mac[6];
+};
+
+enum class MessageType : uint8_t {
+    MSG_PAIR_REQ = 0x01,
+    MSG_IDENTITY_REPLY = 0x02,
+    MSG_PAIR_CONFIRM = 0x03,
+    MSG_PAIR_ACK = 0x04,
+    MSG_KEEPALIVE = 0x05,
+};
+
+struct Packet {
+    uint8_t version;
+    uint8_t type;
+    Identity id;
+    uint32_t monotonicMs;
+    uint8_t reserved[8];
+};
+#pragma pack(pop)
+
+// -----------------------------------------------------------------------------
+// Simple ESP-NOW discovery helper that implements a controller/controlled
+// pairing workflow with identity exchange.
+// -----------------------------------------------------------------------------
+
 class EspNowDiscovery {
 public:
-    // Ensure WiFi remains in AP+STA mode so OTA soft AP stays available;
-    // ESP-NOW should already be initialised by the caller.
     void begin();
-    // Broadcast a discovery message to any nearby devices.
     void discover();
-    // Examine an incoming packet and, if it is part of the discovery
-    // handshake, process it. Returns true if the packet was consumed by the
-    // discovery system and should not be treated as application data.
     bool handleIncoming(const uint8_t *mac, const uint8_t *incomingData, int len);
-    // Return true if at least one peer has been paired.
     bool hasPeers() const;
-    // Retrieve the number of paired peers.
-      int  getPeerCount() const { return peerCount; }
-      // Get the MAC address of a paired peer by index.
-      const uint8_t* getPeer(int index) const { return peerMacs[index]; }
-      // Get the identity name of a paired peer by index.
-      const char* getPeerName(int index) const { return peerNames[index]; }
-      // Find the index of a peer with the provided MAC address. Returns -1
-      // when the peer is unknown.
-      int findPeerIndex(const uint8_t* mac) const;
+    int  getPeerCount() const { return peerCount; }
+    const uint8_t* getPeer(int index) const;
+    const char* getPeerName(int index) const;
+    int findPeerIndex(const uint8_t* mac) const;
+
+    // Utility helpers.
+    static void macToString(const uint8_t* mac, char* buffer, size_t bufferLen);
+    static bool macEqual(const uint8_t* a, const uint8_t* b);
 
 private:
-      static constexpr int kMaxPeers = 5;
-      uint8_t peerMacs[kMaxPeers][6] = {};
-      bool    peerAcked[kMaxPeers] = {};
-      int     peerCount = 0;
-      char    peerNames[kMaxPeers][16] = {};
-  };
+    struct PeerEntry {
+        bool inUse = false;
+        Identity identity{};
+        uint8_t mac[6] = {};
+        uint32_t lastSeen = 0;
+        bool confirmed = false;
+        bool acked = false;
+    };
+
+    struct LinkState {
+        bool paired = false;
+        int peerIndex = -1;
+        uint8_t peerMac[6] = {};
+        uint32_t lastActivityMs = 0;
+        uint32_t lastKeepAliveSentMs = 0;
+        uint32_t lastConfirmSentMs = 0;
+        bool awaitingAck = false;
+    };
+
+    static constexpr int kMaxPeers = 8;
+    static constexpr uint8_t kProtocolVersion = 1;
+
+    void fillSelfIdentity();
+    bool ensurePeer(const uint8_t* mac) const;
+    bool sendPacket(MessageType type, const uint8_t* mac);
+    int upsertPeer(const Identity& id, const uint8_t* mac, uint32_t now);
+    void pruneExpiredPeers(uint32_t now);
+    int selectTarget() const;
+    void resetLink();
+    int computePeerCount() const;
+
+    Identity selfIdentity{};
+    PeerEntry peers[kMaxPeers] = {};
+    int peerCount = 0;
+    LinkState link{};
+    uint32_t lastBroadcastMs = 0;
+};
 
 #endif // ESPNOW_DISCOVERY_H

--- a/src/espnow_discovery.cpp
+++ b/src/espnow_discovery.cpp
@@ -1,123 +1,399 @@
 #include "espnow_discovery.h"
+
+#include <cstdio>
 #include <cstring>
-#include <Arduino.h>
 
-// Broadcast MAC address used for discovery messages.
-static const uint8_t kBroadcastMac[] = {0xff, 0xff, 0xff, 0xff, 0xff, 0xff};
+namespace {
 
-enum PairingType : uint8_t {
-    SCAN_REQUEST  = 0x01,
-    DRONE_IDENTITY = 0x02,
-    ILITE_IDENTITY = 0x03,
-    DRONE_ACK      = 0x04
-};
+constexpr uint8_t kBroadcastMac[6] = {0xff, 0xff, 0xff, 0xff, 0xff, 0xff};
 
-struct IdentityMessage {
-    uint8_t type;
-    char identity[16];
-    uint8_t mac[6];
-} __attribute__((packed));
+void logMac(const char* prefix, const uint8_t* mac) {
+    char buffer[24] = {};
+    EspNowDiscovery::macToString(mac, buffer, sizeof(buffer));
+    Serial.print(prefix);
+    Serial.println(buffer);
+}
 
-static const char kControllerId[] = "ILITEA1";
+}  // namespace
 
 void EspNowDiscovery::begin() {
-    // Ensure station + AP mode so OTA soft AP remains active.
-    // Record any existing peers (e.g. pre-configured target).
-    esp_now_peer_num_t count{};
-    if (esp_now_get_peer_num(&count) == ESP_OK) {
-        peerCount = count.total_num;
+    WiFi.mode(WIFI_AP_STA);
+    esp_err_t chanResult = esp_wifi_set_channel(WIFI_CHANNEL, WIFI_SECOND_CHAN_NONE);
+    if (chanResult != ESP_OK) {
+        Serial.print("[ESP-NOW] Failed to set WiFi channel: ");
+        Serial.println(chanResult);
     }
+
+    fillSelfIdentity();
+
+    // Register the broadcast peer if it is not already present.
+    if (!esp_now_is_peer_exist(kBroadcastMac)) {
+        esp_now_peer_info_t peerInfo{};
+        memcpy(peerInfo.peer_addr, kBroadcastMac, sizeof(peerInfo.peer_addr));
+        peerInfo.channel = WIFI_CHANNEL;
+        peerInfo.encrypt = false;
+        if (esp_now_add_peer(&peerInfo) != ESP_OK) {
+            Serial.println("[ESP-NOW] Failed to add broadcast peer");
+        }
+    }
+
+    for (int i = 0; i < kMaxPeers; ++i) {
+        peers[i] = PeerEntry{};
+    }
+    peerCount = 0;
+    link = LinkState{};
+    lastBroadcastMs = 0;
+
+    Serial.print("[ESP-NOW] Role: ");
+#if DEVICE_ROLE == DEVICE_ROLE_CONTROLLER
+    Serial.println("controller");
+#else
+    Serial.println("controlled");
+#endif
+
+    char idString[64] = {};
+    snprintf(idString, sizeof(idString), "%s/%s (%s)", selfIdentity.customId,
+             selfIdentity.platform, selfIdentity.deviceType);
+    Serial.print("[ESP-NOW] Identity: ");
+    Serial.println(idString);
 }
 
 void EspNowDiscovery::discover() {
-    IdentityMessage msg{};
-    msg.type = SCAN_REQUEST;
-    Serial.println("Sending discovery request");
-    esp_now_send(kBroadcastMac, reinterpret_cast<const uint8_t*>(&msg), sizeof(msg));
+    uint32_t now = millis();
+    pruneExpiredPeers(now);
+
+#if DEVICE_ROLE == DEVICE_ROLE_CONTROLLER
+    if (now - lastBroadcastMs >= BROADCAST_INTERVAL_MS) {
+        sendPacket(MessageType::MSG_PAIR_REQ, kBroadcastMac);
+        lastBroadcastMs = now;
+    }
+
+    if (!link.paired) {
+        int targetIndex = selectTarget();
+        if (targetIndex >= 0) {
+            PeerEntry& target = peers[targetIndex];
+            if (!target.confirmed || now - link.lastConfirmSentMs >= BROADCAST_INTERVAL_MS) {
+                if (sendPacket(MessageType::MSG_PAIR_CONFIRM, target.mac)) {
+                    target.confirmed = true;
+                    link.peerIndex = targetIndex;
+                    link.awaitingAck = true;
+                    link.lastConfirmSentMs = now;
+                    memcpy(link.peerMac, target.mac, sizeof(link.peerMac));
+                    Serial.print("[ESP-NOW] Sent confirm to ");
+                    logMac("", target.mac);
+                }
+            }
+        }
+    } else {
+        if (now - link.lastActivityMs > LINK_TIMEOUT_MS) {
+            Serial.println("[ESP-NOW] Link timeout, resetting");
+            resetLink();
+        } else if (now - link.lastKeepAliveSentMs >= BROADCAST_INTERVAL_MS) {
+            if (sendPacket(MessageType::MSG_KEEPALIVE, link.peerMac)) {
+                link.lastKeepAliveSentMs = now;
+            }
+        }
+    }
+#else
+    if (link.paired) {
+        if (now - link.lastActivityMs > LINK_TIMEOUT_MS) {
+            Serial.println("[ESP-NOW] Controller timeout, resetting link");
+            resetLink();
+        } else if (now - link.lastKeepAliveSentMs >= BROADCAST_INTERVAL_MS) {
+            if (sendPacket(MessageType::MSG_KEEPALIVE, link.peerMac)) {
+                link.lastKeepAliveSentMs = now;
+            }
+        }
+    }
+#endif
 }
 
-bool EspNowDiscovery::handleIncoming(const uint8_t *mac, const uint8_t *incomingData, int len) {
-    // Ignore any packets originating from the universal broadcast address
-    // or our own MAC address. The controller occasionally receives its own
-    // broadcast discovery frames and would otherwise attempt to treat them
-    // as peer telemetry or even pair with itself.
-    if (memcmp(mac, kBroadcastMac, 6) == 0) {
-        return false; // Ignore broadcast traffic
-    }
-    uint8_t selfMac[6];
-    WiFi.macAddress(selfMac);
-    if (memcmp(mac, selfMac, 6) == 0) {
-        return false; // Ignore packets we originated
+bool EspNowDiscovery::handleIncoming(const uint8_t* mac, const uint8_t* incomingData, int len) {
+    if (len < static_cast<int>(sizeof(Packet))) {
+        return false;
     }
 
-    if (len != sizeof(IdentityMessage)) {
-        return false; // Not a pairing message
+    const Packet* packet = reinterpret_cast<const Packet*>(incomingData);
+    if (packet->version != kProtocolVersion) {
+        return false;
     }
 
-    const IdentityMessage* msg = reinterpret_cast<const IdentityMessage*>(incomingData);
+    uint32_t now = millis();
+    MessageType type = static_cast<MessageType>(packet->type);
 
-    if (msg->type == DRONE_IDENTITY) {
-        if (!esp_now_is_peer_exist(mac)) {
-            esp_now_peer_info_t peerInfo{};
-            memcpy(peerInfo.peer_addr, mac, 6);
-            peerInfo.channel = 0;
-            peerInfo.encrypt = false;
-            if (esp_now_add_peer(&peerInfo) == ESP_OK) {
-                Serial.print("Paired with: ");
-                Serial.printf("%02X:%02X:%02X:%02X:%02X:%02X\n", mac[0], mac[1], mac[2], mac[3], mac[4], mac[5]);
-                bool known = false;
-                for (int i = 0; i < peerCount; ++i) {
-                    if (memcmp(peerMacs[i], mac, 6) == 0) {
-                        known = true;
-                        strncpy(peerNames[i], msg->identity, sizeof(peerNames[i])-1);
-                        peerNames[i][sizeof(peerNames[i])-1] = '\0';
-                        break;
-                    }
-                }
-                if (!known && peerCount < kMaxPeers) {
-                    memcpy(peerMacs[peerCount], mac, 6);
-                    peerAcked[peerCount] = false;
-                    strncpy(peerNames[peerCount], msg->identity, sizeof(peerNames[peerCount])-1);
-                    peerNames[peerCount][sizeof(peerNames[peerCount])-1] = '\0';
-                    peerCount++;
-                }
+    switch (type) {
+        case MessageType::MSG_PAIR_REQ:
+#if DEVICE_ROLE == DEVICE_ROLE_CONTROLLED
+            Serial.println("[ESP-NOW] Pair request received");
+            upsertPeer(packet->id, mac, now);
+            ensurePeer(mac);
+            sendPacket(MessageType::MSG_IDENTITY_REPLY, mac);
+            return true;
+#else
+            return false;
+#endif
+
+        case MessageType::MSG_IDENTITY_REPLY:
+#if DEVICE_ROLE == DEVICE_ROLE_CONTROLLER
+            Serial.println("[ESP-NOW] Identity reply received");
+            upsertPeer(packet->id, mac, now);
+            ensurePeer(mac);
+            return true;
+#else
+            return false;
+#endif
+
+        case MessageType::MSG_PAIR_CONFIRM:
+#if DEVICE_ROLE == DEVICE_ROLE_CONTROLLED
+            Serial.println("[ESP-NOW] Pair confirm received");
+            ensurePeer(mac);
+            int index = upsertPeer(packet->id, mac, now);
+            if (index >= 0) {
+                link.paired = true;
+                link.peerIndex = index;
+                memcpy(link.peerMac, mac, sizeof(link.peerMac));
+                link.lastActivityMs = now;
+                link.lastKeepAliveSentMs = now;
+                sendPacket(MessageType::MSG_PAIR_ACK, mac);
+                peers[index].acked = true;
+                Serial.println("[ESP-NOW] Paired with controller");
             }
-        }
+            return true;
+#else
+            return false;
+#endif
 
-        IdentityMessage resp{};
-        resp.type = ILITE_IDENTITY;
-        strncpy(resp.identity, kControllerId, sizeof(resp.identity));
-        WiFi.macAddress(resp.mac);
-        esp_now_send(mac, reinterpret_cast<uint8_t*>(&resp), sizeof(resp));
-        Serial.println("Sending Controller ID ");
-        return true;
-    } else if (msg->type == DRONE_ACK) {
-        Serial.println("Drone Acked");
-        for (int i = 0; i < peerCount; ++i) {
-            if (memcmp(peerMacs[i], mac, 6) == 0) {
-                peerAcked[i] = true;
-                break;
+        case MessageType::MSG_PAIR_ACK:
+#if DEVICE_ROLE == DEVICE_ROLE_CONTROLLER
+            if (link.awaitingAck && macEqual(mac, link.peerMac)) {
+                Serial.println("[ESP-NOW] Pair ack received");
+                link.paired = true;
+                link.awaitingAck = false;
+                link.lastActivityMs = now;
+                link.lastKeepAliveSentMs = now;
+                int index = findPeerIndex(mac);
+                if (index >= 0) {
+                    peers[index].acked = true;
+                    peers[index].lastSeen = now;
+                    peerCount = computePeerCount();
+                }
+                return true;
             }
-        }
-        return true;
+            return false;
+#else
+            return false;
+#endif
+
+        case MessageType::MSG_KEEPALIVE:
+            if (link.paired && macEqual(mac, link.peerMac)) {
+                link.lastActivityMs = now;
+                int index = findPeerIndex(mac);
+                if (index >= 0) {
+                    peers[index].lastSeen = now;
+                }
+                return true;
+            }
+            return false;
     }
 
-    return false; // Not a pairing message
+    return false;
 }
 
 bool EspNowDiscovery::hasPeers() const {
     return peerCount > 0;
 }
 
+const uint8_t* EspNowDiscovery::getPeer(int index) const {
+    if (index < 0 || index >= kMaxPeers) {
+        return nullptr;
+    }
+    return peers[index].inUse ? peers[index].mac : nullptr;
+}
+
+const char* EspNowDiscovery::getPeerName(int index) const {
+    if (index < 0 || index >= kMaxPeers) {
+        return "";
+    }
+    return peers[index].inUse ? peers[index].identity.customId : "";
+}
+
 int EspNowDiscovery::findPeerIndex(const uint8_t* mac) const {
-    if(mac == nullptr){
+    if (!mac) {
         return -1;
     }
-    for(int i = 0; i < peerCount; ++i){
-        if(memcmp(peerMacs[i], mac, 6) == 0){
+    for (int i = 0; i < kMaxPeers; ++i) {
+        if (peers[i].inUse && macEqual(peers[i].mac, mac)) {
             return i;
         }
     }
     return -1;
 }
 
+void EspNowDiscovery::macToString(const uint8_t* mac, char* buffer, size_t bufferLen) {
+    if (!buffer || bufferLen < 18) {
+        return;
+    }
+    if (!mac) {
+        snprintf(buffer, bufferLen, "00:00:00:00:00:00");
+        return;
+    }
+    snprintf(buffer, bufferLen, "%02X:%02X:%02X:%02X:%02X:%02X", mac[0], mac[1],
+             mac[2], mac[3], mac[4], mac[5]);
+}
+
+bool EspNowDiscovery::macEqual(const uint8_t* a, const uint8_t* b) {
+    return a && b && memcmp(a, b, 6) == 0;
+}
+
+void EspNowDiscovery::fillSelfIdentity() {
+    memset(&selfIdentity, 0, sizeof(selfIdentity));
+#if DEVICE_ROLE == DEVICE_ROLE_CONTROLLER
+    strncpy(selfIdentity.deviceType, "controller", sizeof(selfIdentity.deviceType) - 1);
+#else
+    strncpy(selfIdentity.deviceType, "controlled", sizeof(selfIdentity.deviceType) - 1);
+#endif
+    strncpy(selfIdentity.platform, DEVICE_PLATFORM, sizeof(selfIdentity.platform) - 1);
+    strncpy(selfIdentity.customId, DEVICE_CUSTOM_ID, sizeof(selfIdentity.customId) - 1);
+    WiFi.macAddress(selfIdentity.mac);
+}
+
+bool EspNowDiscovery::ensurePeer(const uint8_t* mac) const {
+    if (!mac) {
+        return false;
+    }
+    if (esp_now_is_peer_exist(mac)) {
+        return true;
+    }
+    esp_now_peer_info_t peerInfo{};
+    memcpy(peerInfo.peer_addr, mac, 6);
+    peerInfo.channel = WIFI_CHANNEL;
+    peerInfo.encrypt = false;
+    esp_err_t err = esp_now_add_peer(&peerInfo);
+    if (err != ESP_OK) {
+        Serial.print("[ESP-NOW] Failed to add peer: ");
+        Serial.println(err);
+        return false;
+    }
+    return true;
+}
+
+bool EspNowDiscovery::sendPacket(MessageType type, const uint8_t* mac) {
+    if (!mac) {
+        return false;
+    }
+
+    Packet packet{};
+    packet.version = kProtocolVersion;
+    packet.type = static_cast<uint8_t>(type);
+    packet.id = selfIdentity;
+    WiFi.macAddress(packet.id.mac);
+    memcpy(selfIdentity.mac, packet.id.mac, sizeof(selfIdentity.mac));
+    packet.monotonicMs = millis();
+    memset(packet.reserved, 0, sizeof(packet.reserved));
+
+    if (!macEqual(mac, kBroadcastMac)) {
+        if (!ensurePeer(mac)) {
+            return false;
+        }
+    }
+
+    esp_err_t err = esp_now_send(mac, reinterpret_cast<const uint8_t*>(&packet), sizeof(packet));
+    if (err != ESP_OK) {
+        Serial.print("[ESP-NOW] Send failed: ");
+        Serial.println(err);
+        return false;
+    }
+    return true;
+}
+
+int EspNowDiscovery::upsertPeer(const Identity& id, const uint8_t* mac, uint32_t now) {
+    if (!mac) {
+        return -1;
+    }
+
+    for (int i = 0; i < kMaxPeers; ++i) {
+        if (peers[i].inUse && macEqual(peers[i].mac, mac)) {
+            peers[i].identity = id;
+            memcpy(peers[i].mac, mac, 6);
+            peers[i].lastSeen = now;
+            peerCount = computePeerCount();
+            return i;
+        }
+    }
+
+    for (int i = 0; i < kMaxPeers; ++i) {
+        if (!peers[i].inUse) {
+            peers[i].inUse = true;
+            peers[i].identity = id;
+            memcpy(peers[i].mac, mac, 6);
+            peers[i].lastSeen = now;
+            peers[i].confirmed = false;
+            peers[i].acked = false;
+            peerCount = computePeerCount();
+            char label[24] = {};
+            macToString(mac, label, sizeof(label));
+            Serial.print("[ESP-NOW] Discovered peer: ");
+            Serial.print(id.customId);
+            Serial.print(" @ ");
+            Serial.println(label);
+            return i;
+        }
+    }
+
+    Serial.println("[ESP-NOW] Peer table full");
+    return -1;
+}
+
+void EspNowDiscovery::pruneExpiredPeers(uint32_t now) {
+    bool changed = false;
+    for (int i = 0; i < kMaxPeers; ++i) {
+        if (peers[i].inUse && now - peers[i].lastSeen > DEVICE_TTL_MS) {
+            char label[24] = {};
+            macToString(peers[i].mac, label, sizeof(label));
+            Serial.print("[ESP-NOW] Removing stale peer: ");
+            Serial.println(label);
+            if (link.peerIndex == i) {
+                resetLink();
+            }
+            peers[i] = PeerEntry{};
+            changed = true;
+        }
+    }
+    if (changed) {
+        peerCount = computePeerCount();
+    }
+}
+
+int EspNowDiscovery::selectTarget() const {
+    int fallback = -1;
+    for (int i = 0; i < kMaxPeers; ++i) {
+        if (!peers[i].inUse) {
+            continue;
+        }
+        if (!peers[i].acked) {
+            return i;
+        }
+        if (fallback < 0) {
+            fallback = i;
+        }
+    }
+    return fallback;
+}
+
+void EspNowDiscovery::resetLink() {
+    if (link.peerIndex >= 0 && link.peerIndex < kMaxPeers) {
+        peers[link.peerIndex].acked = false;
+        peers[link.peerIndex].confirmed = false;
+    }
+    link = LinkState{};
+}
+
+int EspNowDiscovery::computePeerCount() const {
+    int count = 0;
+    for (int i = 0; i < kMaxPeers; ++i) {
+        if (peers[i].inUse) {
+            ++count;
+        }
+    }
+    return count;
+}

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -690,6 +690,12 @@ unsigned long lastBtnModeMillis;
 bool ispressed;
 
 void loop() {
+  uint32_t now = millis();
+  static uint32_t lastPairMaintenance = 0;
+  if(now - lastPairMaintenance >= 200){
+    discovery.discover();
+    lastPairMaintenance = now;
+  }
   ArduinoOTA.handle();
   checkPress();
   beep();


### PR DESCRIPTION
## Summary
- add configurable identity and packet definitions for ESP-NOW roles and platforms
- replace the discovery helper with an ESP-NOW pairing state machine that handles confirms, ACKs, keepalives, and TTL pruning while keeping WiFi in AP+STA mode
- call the discovery maintenance loop periodically to drive broadcasts and link supervision

## Testing
- platformio run *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d327db013c832a8489836bd4f4d0df