### PR TITLE
Refine module handling for incoming data and dashboards

### DIFF
--- a/include/audio_feedback.h
+++ b/include/audio_feedback.h
@@ -1,0 +1,19 @@
+#pragma once
+#include <Arduino.h>
+
+enum class AudioCue : uint8_t {
+  Scroll,
+  Select,
+  Back,
+  PeerRequest,
+  PeerAcknowledge,
+  PeerDiscovered,
+  ToggleOn,
+  ToggleOff,
+  Error
+};
+
+void audioFeedback(AudioCue cue);
+void audioUpdate();
+void audioSetup();
+void audioPlayStartup();

--- a/include/display.h
+++ b/include/display.h
@@ -4,6 +4,7 @@
 #include "espnow_discovery.h"
 #include "telemetry.h"
 #include "input.h"
+#include "ui_modules.h"
 
 extern U8G2_SH1106_128X64_NONAME_F_HW_I2C oled;
 extern EspNowDiscovery discovery;
@@ -17,9 +18,9 @@ extern int selectedPeer;
 extern int lastEncoderCount;
 extern unsigned long lastDiscoveryTime;
 extern int infoPeer;
-extern bool pairedIsBulky;
-extern bool pairedIsThegill;
 extern int gillConfigIndex;
+extern int globalMenuIndex;
+extern int dashboardFocusIndex;
 
 extern byte batteryLevel;
 extern byte Front_Distance;
@@ -52,9 +53,16 @@ void drawHomeMenu();
 void drawHomeFooter();
 void drawDashboard();
 void drawThegillDashboard();
+void drawGenericDashboard();
+void drawBulkyDashboard();
 void drawAbout();
 void drawBootScreen();
 void drawThegillConfig();
+void drawGlobalMenu();
+void drawLayoutCardFrame(int16_t x, int16_t y, const char* title, const char* subtitle, bool focused);
+void drawGenericLayoutCard(const ModuleState& state, int16_t x, int16_t y, bool focused);
+void drawBulkyLayoutCard(const ModuleState& state, int16_t x, int16_t y, bool focused);
+void drawThegillLayoutCard(const ModuleState& state, int16_t x, int16_t y, bool focused);
 void irData();
 void Line_detection();
 void Pid_Tuner();

--- a/include/ui_modules.h
+++ b/include/ui_modules.h
@@ -1,0 +1,48 @@
+#pragma once
+#include <Arduino.h>
+
+enum class PeerKind : uint8_t {
+  None,
+  Generic,
+  Bulky,
+  Thegill
+};
+
+struct ModuleState;
+
+struct FunctionActionOption {
+  const char* name;
+  const char* shortLabel;
+  void (*invoke)(ModuleState& state, size_t slot);
+};
+
+struct ModuleDescriptor {
+  PeerKind kind;
+  const char* displayName;
+  void (*drawDashboard)();
+  void (*drawLayoutCard)(const ModuleState& state, int16_t x, int16_t y, bool focused);
+  void (*handleIncoming)(ModuleState& state, const uint8_t* data, size_t length);
+  void (*updateControl)();
+  const uint8_t* (*preparePayload)(size_t& size);
+  const FunctionActionOption* functionOptions;
+  size_t functionOptionCount;
+};
+
+struct ModuleState {
+  const ModuleDescriptor* descriptor;
+  bool wifiEnabled;
+  uint8_t assignedActions[3];
+  bool functionOutputs[3];
+};
+
+size_t getModuleStateCount();
+ModuleState* getModuleState(size_t index);
+ModuleState* findModuleByKind(PeerKind kind);
+ModuleState* findModuleByName(const char* name);
+ModuleState* getActiveModule();
+void setActiveModule(ModuleState* state);
+const FunctionActionOption* getAssignedAction(const ModuleState& state, size_t slot);
+void cycleAssignedAction(ModuleState& state, size_t slot, int delta);
+void setFunctionOutput(ModuleState& state, size_t slot, bool active);
+bool getFunctionOutput(const ModuleState& state, size_t slot);
+void toggleModuleWifi(ModuleState& state);

--- a/src/audio_feedback.cpp
+++ b/src/audio_feedback.cpp
@@ -1,0 +1,77 @@
+#include "audio_feedback.h"
+#include <DacESP32.h>
+
+namespace {
+constexpr gpio_num_t kBuzzerPin = GPIO_NUM_26;
+struct Tone {
+  uint16_t frequency;
+  uint16_t durationMs;
+};
+
+struct QueuedTone {
+  Tone tone;
+  uint32_t endMs;
+  bool active;
+};
+
+DacESP32 buzzer(kBuzzerPin);
+QueuedTone currentTone{{0,0},0,false};
+
+Tone cueToTone(AudioCue cue){
+  switch(cue){
+    case AudioCue::Scroll:        return {520, 80};
+    case AudioCue::Select:        return {720, 140};
+    case AudioCue::Back:          return {360, 120};
+    case AudioCue::PeerRequest:   return {880, 180};
+    case AudioCue::PeerAcknowledge:return {620, 120};
+    case AudioCue::PeerDiscovered:return {940, 160};
+    case AudioCue::ToggleOn:      return {780, 120};
+    case AudioCue::ToggleOff:     return {300, 120};
+    case AudioCue::Error:         return {220, 200};
+    default:                      return {400, 120};
+  }
+}
+
+void startTone(const Tone& tone){
+  buzzer.enable();
+  buzzer.outputCW(tone.frequency);
+  currentTone = {tone, millis() + tone.durationMs, true};
+}
+
+void stopTone(){
+  buzzer.outputCW(0);
+  buzzer.disable();
+  currentTone = {{0,0},0,false};
+}
+
+} // namespace
+
+void audioSetup(){
+  buzzer.enable();
+  buzzer.outputCW(0);
+  buzzer.disable();
+}
+
+void audioPlayStartup(){
+  const Tone startup[] = {{320,120}, {480,120}, {640,160}, {0,60}};
+  for(const Tone& tone : startup){
+    if(tone.frequency == 0){
+      stopTone();
+      delay(tone.durationMs);
+    }else{
+      startTone(tone);
+      delay(tone.durationMs);
+    }
+  }
+  stopTone();
+}
+
+void audioFeedback(AudioCue cue){
+  startTone(cueToTone(cue));
+}
+
+void audioUpdate(){
+  if(currentTone.active && millis() >= currentTone.endMs){
+    stopTone();
+  }
+}

--- a/src/espnow_discovery.cpp
+++ b/src/espnow_discovery.cpp
@@ -1,4 +1,5 @@
 #include "espnow_discovery.h"
+#include "audio_feedback.h"
 
 #include <cstdio>
 #include <cstring>
@@ -128,6 +129,7 @@ bool EspNowDiscovery::handleIncoming(const uint8_t* mac, const uint8_t* incoming
             upsertPeer(packet->id, mac, now);
             ensurePeer(mac);
             sendPacket(MessageType::MSG_IDENTITY_REPLY, mac);
+            audioFeedback(AudioCue::PeerRequest);
             return true;
 #else
             return false;
@@ -138,6 +140,7 @@ bool EspNowDiscovery::handleIncoming(const uint8_t* mac, const uint8_t* incoming
             Serial.println("[ESP-NOW] Identity reply received");
             upsertPeer(packet->id, mac, now);
             ensurePeer(mac);
+            audioFeedback(AudioCue::PeerDiscovered);
             return true;
 #else
             return false;
@@ -157,6 +160,7 @@ bool EspNowDiscovery::handleIncoming(const uint8_t* mac, const uint8_t* incoming
                 sendPacket(MessageType::MSG_PAIR_ACK, mac);
                 peers[index].acked = true;
                 Serial.println("[ESP-NOW] Paired with controller");
+                audioFeedback(AudioCue::PeerAcknowledge);
             }
             return true;
 #else
@@ -177,6 +181,7 @@ bool EspNowDiscovery::handleIncoming(const uint8_t* mac, const uint8_t* incoming
                     peers[index].lastSeen = now;
                     peerCount = computePeerCount();
                 }
+                audioFeedback(AudioCue::PeerAcknowledge);
                 return true;
             }
             return false;


### PR DESCRIPTION
## Summary
- extend the module descriptor with a `handleIncoming` hook and dispatch incoming ESP-NOW payloads through it
- move Bulky telemetry parsing into its module handler and rely on descriptor dashboards instead of a hard-coded peer switch
- retain the generic dashboard fallback whenever no module-specific renderer is supplied

## Testing
- platformio run *(fails: PlatformIO CLI not installed in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d32cbea7f8832ab09f012873de63fe