### PR TITLE
Add connection log screen and command packet support

### DIFF
--- a/include/connection_log.h
+++ b/include/connection_log.h
@@ -1,0 +1,22 @@
+#pragma once
+
+#include <Arduino.h>
+
+// Initializes the connection log system. Currently a no-op but provided for completeness.
+void connectionLogInit();
+
+// Adds a message to the log (truncated if necessary).
+void connectionLogAdd(const char* message);
+
+// Adds a formatted message to the log using printf-style formatting.
+void connectionLogAddf(const char* fmt, ...);
+
+// Returns the number of log entries currently stored.
+size_t connectionLogGetCount();
+
+// Returns a pointer to the log entry at the provided index (0 = oldest).
+// Returns nullptr if the index is out of range.
+const char* connectionLogGetEntry(size_t index);
+
+// Clears all stored log entries.
+void connectionLogClear();

--- a/include/display.h
+++ b/include/display.h
@@ -21,6 +21,18 @@ extern int infoPeer;
 extern int gillConfigIndex;
 extern int globalMenuIndex;
 extern int dashboardFocusIndex;
+extern int logScrollOffset;
+
+constexpr byte DISPLAY_MODE_HOME = 0;
+constexpr byte DISPLAY_MODE_TELEMETRY = 1;
+constexpr byte DISPLAY_MODE_PID = 2;
+constexpr byte DISPLAY_MODE_ORIENTATION = 3;
+constexpr byte DISPLAY_MODE_PAIRING = 4;
+constexpr byte DISPLAY_MODE_DASHBOARD = 5;
+constexpr byte DISPLAY_MODE_ABOUT = 6;
+constexpr byte DISPLAY_MODE_PEER_INFO = 7;
+constexpr byte DISPLAY_MODE_GLOBAL_MENU = 8;
+constexpr byte DISPLAY_MODE_LOG = 9;
 
 extern byte batteryLevel;
 extern byte Front_Distance;
@@ -55,6 +67,7 @@ void drawDashboard();
 void drawThegillDashboard();
 void drawGenericDashboard();
 void drawBulkyDashboard();
+void drawConnectionLog();
 void drawAbout();
 void drawBootScreen();
 void drawThegillConfig();

--- a/include/espnow_discovery.h
+++ b/include/espnow_discovery.h
@@ -49,6 +49,7 @@ enum class MessageType : uint8_t {
     MSG_PAIR_CONFIRM = 0x03,
     MSG_PAIR_ACK = 0x04,
     MSG_KEEPALIVE = 0x05,
+    MSG_COMMAND = 0x06,
 };
 
 struct Packet {
@@ -57,6 +58,11 @@ struct Packet {
     Identity id;
     uint32_t monotonicMs;
     uint8_t reserved[8];
+};
+
+struct CommandPacket {
+    Packet header;
+    char command[48];
 };
 #pragma pack(pop)
 
@@ -75,6 +81,7 @@ public:
     const uint8_t* getPeer(int index) const;
     const char* getPeerName(int index) const;
     int findPeerIndex(const uint8_t* mac) const;
+    bool sendCommand(const uint8_t* mac, const char* command);
 
     // Utility helpers.
     static void macToString(const uint8_t* mac, char* buffer, size_t bufferLen);

--- a/src/connection_log.cpp
+++ b/src/connection_log.cpp
@@ -1,0 +1,81 @@
+#include "connection_log.h"
+
+#include <stdarg.h>
+#include <stdio.h>
+#include <string.h>
+
+namespace {
+constexpr size_t kMaxEntries = 32;
+constexpr size_t kEntryLength = 48;
+
+char logEntries[kMaxEntries][kEntryLength] = {};
+size_t logCount = 0;
+size_t nextIndex = 0;
+
+size_t oldestIndex() {
+  if (logCount == 0) {
+    return 0;
+  }
+  if (logCount < kMaxEntries) {
+    return 0;
+  }
+  return nextIndex;
+}
+
+void writeEntry(const char* text) {
+  if (!text) {
+    return;
+  }
+  strncpy(logEntries[nextIndex], text, kEntryLength - 1);
+  logEntries[nextIndex][kEntryLength - 1] = '\0';
+  nextIndex = (nextIndex + 1) % kMaxEntries;
+  if (logCount < kMaxEntries) {
+    ++logCount;
+  }
+}
+
+}  // namespace
+
+void connectionLogInit() {
+  connectionLogClear();
+}
+
+void connectionLogAdd(const char* message) {
+  if (!message || message[0] == '\0') {
+    return;
+  }
+  writeEntry(message);
+}
+
+void connectionLogAddf(const char* fmt, ...) {
+  if (!fmt) {
+    return;
+  }
+  char buffer[kEntryLength];
+  va_list args;
+  va_start(args, fmt);
+  vsnprintf(buffer, sizeof(buffer), fmt, args);
+  va_end(args);
+  writeEntry(buffer);
+}
+
+size_t connectionLogGetCount() {
+  return logCount;
+}
+
+const char* connectionLogGetEntry(size_t index) {
+  if (index >= logCount) {
+    return nullptr;
+  }
+  size_t start = oldestIndex();
+  size_t actual = (start + index) % kMaxEntries;
+  return logEntries[actual];
+}
+
+void connectionLogClear() {
+  for (size_t i = 0; i < kMaxEntries; ++i) {
+    logEntries[i][0] = '\0';
+  }
+  logCount = 0;
+  nextIndex = 0;
+}

--- a/src/espnow_discovery.cpp
+++ b/src/espnow_discovery.cpp
@@ -1,5 +1,6 @@
 #include "espnow_discovery.h"
 #include "audio_feedback.h"
+#include "connection_log.h"
 
 #include <cstdio>
 #include <cstring>
@@ -23,9 +24,17 @@ void EspNowDiscovery::begin() {
     if (chanResult != ESP_OK) {
         Serial.print("[ESP-NOW] Failed to set WiFi channel: ");
         Serial.println(chanResult);
+        connectionLogAddf("WiFi channel error: %d", chanResult);
     }
 
     fillSelfIdentity();
+    connectionLogAdd("ESP-NOW begin");
+#if DEVICE_ROLE == DEVICE_ROLE_CONTROLLER
+    connectionLogAdd("Role: controller");
+#else
+    connectionLogAdd("Role: controlled");
+#endif
+    connectionLogAddf("Identity: %s/%s", selfIdentity.customId, selfIdentity.deviceType);
 
     // Register the broadcast peer if it is not already present.
     if (!esp_now_is_peer_exist(kBroadcastMac)) {
@@ -89,6 +98,7 @@ void EspNowDiscovery::discover() {
         if (now - link.lastActivityMs > LINK_TIMEOUT_MS) {
             Serial.println("[ESP-NOW] Link timeout, resetting");
             resetLink();
+            connectionLogAdd("Link timeout, resetting");
         } else if (now - link.lastKeepAliveSentMs >= BROADCAST_INTERVAL_MS) {
             if (sendPacket(MessageType::MSG_KEEPALIVE, link.peerMac)) {
                 link.lastKeepAliveSentMs = now;
@@ -100,6 +110,7 @@ void EspNowDiscovery::discover() {
         if (now - link.lastActivityMs > LINK_TIMEOUT_MS) {
             Serial.println("[ESP-NOW] Controller timeout, resetting link");
             resetLink();
+            connectionLogAdd("Controller timeout, resetting link");
         } else if (now - link.lastKeepAliveSentMs >= BROADCAST_INTERVAL_MS) {
             if (sendPacket(MessageType::MSG_KEEPALIVE, link.peerMac)) {
                 link.lastKeepAliveSentMs = now;
@@ -126,6 +137,9 @@ bool EspNowDiscovery::handleIncoming(const uint8_t* mac, const uint8_t* incoming
         case MessageType::MSG_PAIR_REQ:
 #if DEVICE_ROLE == DEVICE_ROLE_CONTROLLED
             Serial.println("[ESP-NOW] Pair request received");
+            char pairLabel[24] = {};
+            macToString(mac, pairLabel, sizeof(pairLabel));
+            connectionLogAddf("Pair request from %s", pairLabel);
             upsertPeer(packet->id, mac, now);
             ensurePeer(mac);
             sendPacket(MessageType::MSG_IDENTITY_REPLY, mac);
@@ -141,6 +155,7 @@ bool EspNowDiscovery::handleIncoming(const uint8_t* mac, const uint8_t* incoming
             upsertPeer(packet->id, mac, now);
             ensurePeer(mac);
             audioFeedback(AudioCue::PeerDiscovered);
+            connectionLogAddf("Identity reply: %s", packet->id.customId);
             return true;
 #else
             return false;
@@ -149,6 +164,9 @@ bool EspNowDiscovery::handleIncoming(const uint8_t* mac, const uint8_t* incoming
         case MessageType::MSG_PAIR_CONFIRM:
 #if DEVICE_ROLE == DEVICE_ROLE_CONTROLLED
             Serial.println("[ESP-NOW] Pair confirm received");
+            char confirmLabel[24] = {};
+            macToString(mac, confirmLabel, sizeof(confirmLabel));
+            connectionLogAddf("Pair confirm from %s", confirmLabel);
             ensurePeer(mac);
             int index = upsertPeer(packet->id, mac, now);
             if (index >= 0) {
@@ -161,6 +179,7 @@ bool EspNowDiscovery::handleIncoming(const uint8_t* mac, const uint8_t* incoming
                 peers[index].acked = true;
                 Serial.println("[ESP-NOW] Paired with controller");
                 audioFeedback(AudioCue::PeerAcknowledge);
+                connectionLogAddf("Paired with %s", packet->id.customId);
             }
             return true;
 #else
@@ -171,6 +190,8 @@ bool EspNowDiscovery::handleIncoming(const uint8_t* mac, const uint8_t* incoming
 #if DEVICE_ROLE == DEVICE_ROLE_CONTROLLER
             if (link.awaitingAck && macEqual(mac, link.peerMac)) {
                 Serial.println("[ESP-NOW] Pair ack received");
+                char ackLabel[24] = {};
+                macToString(mac, ackLabel, sizeof(ackLabel));
                 link.paired = true;
                 link.awaitingAck = false;
                 link.lastActivityMs = now;
@@ -182,6 +203,7 @@ bool EspNowDiscovery::handleIncoming(const uint8_t* mac, const uint8_t* incoming
                     peerCount = computePeerCount();
                 }
                 audioFeedback(AudioCue::PeerAcknowledge);
+                connectionLogAddf("Pair ack from %s", ackLabel);
                 return true;
             }
             return false;
@@ -199,6 +221,17 @@ bool EspNowDiscovery::handleIncoming(const uint8_t* mac, const uint8_t* incoming
                 return true;
             }
             return false;
+
+        case MessageType::MSG_COMMAND:
+            if (len >= static_cast<int>(sizeof(CommandPacket))) {
+                const CommandPacket* cmd = reinterpret_cast<const CommandPacket*>(incomingData);
+                char commandLabel[24] = {};
+                macToString(mac, commandLabel, sizeof(commandLabel));
+                connectionLogAddf("Command from %s: %s", commandLabel, cmd->command);
+            } else {
+                connectionLogAdd("Command packet truncated");
+            }
+            return true;
     }
 
     return false;
@@ -306,6 +339,7 @@ bool EspNowDiscovery::sendPacket(MessageType type, const uint8_t* mac) {
     if (err != ESP_OK) {
         Serial.print("[ESP-NOW] Send failed: ");
         Serial.println(err);
+        connectionLogAddf("Send failed (%u): %d", static_cast<unsigned>(type), err);
         return false;
     }
     return true;
@@ -322,6 +356,7 @@ int EspNowDiscovery::upsertPeer(const Identity& id, const uint8_t* mac, uint32_t
             memcpy(peers[i].mac, mac, 6);
             peers[i].lastSeen = now;
             peerCount = computePeerCount();
+            connectionLogAddf("Peer updated: %s", id.customId);
             return i;
         }
     }
@@ -341,11 +376,13 @@ int EspNowDiscovery::upsertPeer(const Identity& id, const uint8_t* mac, uint32_t
             Serial.print(id.customId);
             Serial.print(" @ ");
             Serial.println(label);
+            connectionLogAddf("Peer discovered: %s", id.customId);
             return i;
         }
     }
 
     Serial.println("[ESP-NOW] Peer table full");
+    connectionLogAdd("Peer table full");
     return -1;
 }
 
@@ -362,6 +399,7 @@ void EspNowDiscovery::pruneExpiredPeers(uint32_t now) {
             }
             peers[i] = PeerEntry{};
             changed = true;
+            connectionLogAddf("Peer stale: %s", label);
         }
     }
     if (changed) {
@@ -391,6 +429,7 @@ void EspNowDiscovery::resetLink() {
         peers[link.peerIndex].confirmed = false;
     }
     link = LinkState{};
+    connectionLogAdd("Link reset");
 }
 
 int EspNowDiscovery::computePeerCount() const {
@@ -401,4 +440,41 @@ int EspNowDiscovery::computePeerCount() const {
         }
     }
     return count;
+}
+
+bool EspNowDiscovery::sendCommand(const uint8_t* mac, const char* command) {
+    if (!mac || !command) {
+        return false;
+    }
+
+    CommandPacket packet{};
+    packet.header.version = kProtocolVersion;
+    packet.header.type = static_cast<uint8_t>(MessageType::MSG_COMMAND);
+    packet.header.id = selfIdentity;
+    WiFi.macAddress(packet.header.id.mac);
+    memcpy(selfIdentity.mac, packet.header.id.mac, sizeof(selfIdentity.mac));
+    packet.header.monotonicMs = millis();
+    memset(packet.header.reserved, 0, sizeof(packet.header.reserved));
+    strncpy(packet.command, command, sizeof(packet.command) - 1);
+    packet.command[sizeof(packet.command) - 1] = '\0';
+
+    if (!macEqual(mac, kBroadcastMac)) {
+        if (!ensurePeer(mac)) {
+            connectionLogAdd("Command target unavailable");
+            return false;
+        }
+    }
+
+    esp_err_t err = esp_now_send(mac, reinterpret_cast<const uint8_t*>(&packet), sizeof(packet));
+    if (err != ESP_OK) {
+        Serial.print("[ESP-NOW] Command send failed: ");
+        Serial.println(err);
+        connectionLogAddf("Command send failed: %d", err);
+        return false;
+    }
+
+    char label[24] = {};
+    macToString(mac, label, sizeof(label));
+    connectionLogAddf("Command sent to %s: %s", label, packet.command);
+    return true;
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -9,6 +9,7 @@
 #include "freertos/FreeRTOS.h"
 #include "freertos/task.h"
 #include "display.h"
+#include "connection_log.h"
 #include "input.h"
 #include "telemetry.h"
 #include "thegill.h"
@@ -227,25 +228,31 @@ void OnDataRecv(const uint8_t * mac, const uint8_t *incomingData, int len) {
       const char* peerName = discovery.getPeerName(peerIndex);
       ModuleState* module = findModuleByName(peerName);
       setActiveModule(module);
-      switch(module->descriptor->kind){
-        case PeerKind::Bulky:
-          botMotionState = STOP;
-          botSpeed = 0;
-          bulkyCommand = BulkyCommand{0, 0, STOP, {0, 0, 0}};
-          bulkyHonkLatch = false;
-          bulkyLightLatch = false;
-          bulkySlowMode = false;
-          break;
-        case PeerKind::Thegill:
-          resetThegillState();
-          gillHonkLatch = false;
-          gillConfigIndex = 0;
-          break;
-        case PeerKind::Generic:
-        default:
-          break;
+      if(module && module->descriptor){
+        switch(module->descriptor->kind){
+          case PeerKind::Bulky:
+            botMotionState = STOP;
+            botSpeed = 0;
+            bulkyCommand = BulkyCommand{0, 0, STOP, {0, 0, 0}};
+            bulkyHonkLatch = false;
+            bulkyLightLatch = false;
+            bulkySlowMode = false;
+            break;
+          case PeerKind::Thegill:
+            resetThegillState();
+            gillHonkLatch = false;
+            gillConfigIndex = 0;
+            break;
+          case PeerKind::Generic:
+          default:
+            break;
+        }
       }
+      connectionLogAddf("Active peer: %s", peerName);
     }
+    displayMode = DISPLAY_MODE_DASHBOARD;
+    dashboardFocusIndex = 0;
+    logScrollOffset = 0;
     audioFeedback(AudioCue::PeerDiscovered);
     return;
   }
@@ -827,15 +834,16 @@ static void processFunctionKeys(){
 void displayTask(void* pvParameters){
   for(;;){
     switch(displayMode){
-      case 0: drawHomeMenu(); break;
-      case 1: drawTelemetryInfo(); break;
-      case 2: drawPidGraph(); break;
-      case 3: drawOrientationCube(); break;
-      case 4: drawPairingMenu(); break;
-      case 5: drawDashboard(); break;
-      case 6: drawAbout(); break;
-      case 7: drawPeerInfo(); break;
-      case 8: drawGlobalMenu(); break;
+      case DISPLAY_MODE_HOME: drawHomeMenu(); break;
+      case DISPLAY_MODE_TELEMETRY: drawTelemetryInfo(); break;
+      case DISPLAY_MODE_PID: drawPidGraph(); break;
+      case DISPLAY_MODE_ORIENTATION: drawOrientationCube(); break;
+      case DISPLAY_MODE_PAIRING: drawPairingMenu(); break;
+      case DISPLAY_MODE_DASHBOARD: drawDashboard(); break;
+      case DISPLAY_MODE_ABOUT: drawAbout(); break;
+      case DISPLAY_MODE_PEER_INFO: drawPeerInfo(); break;
+      case DISPLAY_MODE_GLOBAL_MENU: drawGlobalMenu(); break;
+      case DISPLAY_MODE_LOG: drawConnectionLog(); break;
     }
     appendPidSample();
     vTaskDelay(10 / portTICK_PERIOD_MS);
@@ -874,6 +882,9 @@ void setup() {
   //==================================
 
   initializeModuleAssignments();
+
+  connectionLogInit();
+  connectionLogAdd("System boot");
 
   //Init Verbose =====================
   verboseON
@@ -988,13 +999,15 @@ void loop() {
     connected = false;
     discovery.discover();
     lastDiscoveryTime = now;
-    displayMode = 4;
+    displayMode = DISPLAY_MODE_LOG;
+    logScrollOffset = 0;
     selectedPeer = 0;
     botMotionState = STOP;
     botSpeed = 0;
     if(kind == PeerKind::Thegill){
       resetThegillState();
     }
+    connectionLogAdd("Link timeout");
   }
 
   if(kind != PeerKind::Thegill && now - lastBtnModeMillis >= 200){
@@ -1010,13 +1023,13 @@ void loop() {
     lastBtnModeMillis = now;
   }
 
-  if(displayMode == 4 && now - lastDiscoveryTime > 2000){
+  if(displayMode == DISPLAY_MODE_PAIRING && now - lastDiscoveryTime > 2000){
     discovery.discover();
     lastDiscoveryTime = now;
   }
 
   int delta = encoderCount - lastEncoderCount;
-  if(displayMode == 0){
+  if(displayMode == DISPLAY_MODE_HOME){
     size_t moduleCount = getModuleStateCount();
     if(delta != 0 && moduleCount > 0){
       homeMenuIndex = (homeMenuIndex + delta) % static_cast<int>(moduleCount);
@@ -1024,21 +1037,21 @@ void loop() {
       lastEncoderCount = encoderCount;
       audioFeedback(AudioCue::Scroll);
     }
-  } else if(displayMode == 1 && kind == PeerKind::Thegill){
+  } else if(displayMode == DISPLAY_MODE_TELEMETRY && kind == PeerKind::Thegill){
     if(delta != 0){
       gillConfigIndex = (gillConfigIndex + delta) % 3;
       if(gillConfigIndex < 0) gillConfigIndex += 3;
       lastEncoderCount = encoderCount;
       audioFeedback(AudioCue::Scroll);
     }
-  } else if(displayMode == 2){
+  } else if(displayMode == DISPLAY_MODE_PID){
     if(delta != 0){
       pidGraphIndex = (pidGraphIndex + delta) % 3;
       if(pidGraphIndex < 0) pidGraphIndex += 3;
       lastEncoderCount = encoderCount;
       audioFeedback(AudioCue::Scroll);
     }
-  } else if(displayMode == 4){
+  } else if(displayMode == DISPLAY_MODE_PAIRING){
     int count = discovery.getPeerCount() + 1;
     if(delta != 0 && count > 0){
       selectedPeer = (selectedPeer + delta) % count;
@@ -1046,15 +1059,27 @@ void loop() {
       lastEncoderCount = encoderCount;
       audioFeedback(AudioCue::Scroll);
     }
-  } else if(displayMode == 5){
+  } else if(displayMode == DISPLAY_MODE_DASHBOARD){
     if(delta != 0){
       dashboardFocusIndex = (dashboardFocusIndex + delta) % 3;
       if(dashboardFocusIndex < 0) dashboardFocusIndex += 3;
       lastEncoderCount = encoderCount;
       audioFeedback(AudioCue::Scroll);
     }
-  } else if(displayMode == 8){
-    const int baseCount = 6;
+  } else if(displayMode == DISPLAY_MODE_LOG){
+    size_t count = connectionLogGetCount();
+    if(delta != 0 && count > 0){
+      int visibleLines = 6;
+      int maxOffset = 0;
+      if(count > static_cast<size_t>(visibleLines)){
+        maxOffset = static_cast<int>(count) - visibleLines;
+      }
+      logScrollOffset = constrain(logScrollOffset - delta, 0, maxOffset);
+      lastEncoderCount = encoderCount;
+      audioFeedback(AudioCue::Scroll);
+    }
+  } else if(displayMode == DISPLAY_MODE_GLOBAL_MENU){
+    const int baseCount = 7;
     const int totalEntries = baseCount + 3 + 1 + 1;
     if(delta != 0){
       globalMenuIndex = (globalMenuIndex + delta) % totalEntries;
@@ -1062,7 +1087,7 @@ void loop() {
       lastEncoderCount = encoderCount;
       audioFeedback(AudioCue::Scroll);
     }
-  } else if(displayMode == 3 || displayMode == 6 || displayMode == 7){
+  } else if(displayMode == DISPLAY_MODE_ORIENTATION || displayMode == DISPLAY_MODE_ABOUT || displayMode == DISPLAY_MODE_PEER_INFO){
     if(delta != 0){
       homeSelected = !homeSelected;
       lastEncoderCount = encoderCount;
@@ -1075,9 +1100,9 @@ void loop() {
 
   if(encoderBtnState){
     encoderBtnState = 0;
-    if(displayMode == 5){
+    if(displayMode == DISPLAY_MODE_DASHBOARD){
       if(dashboardFocusIndex == 1){
-        displayMode = 8;
+        displayMode = DISPLAY_MODE_GLOBAL_MENU;
         globalMenuIndex = 0;
         audioFeedback(AudioCue::Select);
       } else if(dashboardFocusIndex == 2){
@@ -1085,43 +1110,43 @@ void loop() {
           toggleModuleWifi(*active);
         }
       } else {
-        displayMode = 0;
+        displayMode = DISPLAY_MODE_HOME;
         homeMenuIndex = 0;
         audioFeedback(AudioCue::Back);
       }
-    } else if(displayMode == 0){
+    } else if(displayMode == DISPLAY_MODE_HOME){
       ModuleState* selected = getModuleState(static_cast<size_t>(homeMenuIndex));
       if(selected){
         setActiveModule(selected);
-        displayMode = 5;
+        displayMode = DISPLAY_MODE_DASHBOARD;
         dashboardFocusIndex = 0;
         audioFeedback(AudioCue::Select);
       }
-    } else if(displayMode == 4){
+    } else if(displayMode == DISPLAY_MODE_PAIRING){
       int count = discovery.getPeerCount();
       if(selectedPeer == count){
-        displayMode = 0;
+        displayMode = DISPLAY_MODE_HOME;
         audioFeedback(AudioCue::Back);
       } else if(count > 0){
         infoPeer = selectedPeer;
-        displayMode = 7;
+        displayMode = DISPLAY_MODE_PEER_INFO;
         audioFeedback(AudioCue::Select);
       }
-    } else if(displayMode == 1 && kind == PeerKind::Thegill){
+    } else if(displayMode == DISPLAY_MODE_TELEMETRY && kind == PeerKind::Thegill){
       if(active){
         if(gillConfigIndex == 0){
           actionToggleGillMode(*active, 0);
         } else if(gillConfigIndex == 1){
           actionCycleGillEasing(*active, 1);
         } else {
-          displayMode = 0;
+          displayMode = DISPLAY_MODE_HOME;
           homeMenuIndex = 1;
           audioFeedback(AudioCue::Back);
         }
       }
-    } else if(displayMode == 7){
+    } else if(displayMode == DISPLAY_MODE_PEER_INFO){
       if(homeSelected){
-        displayMode = 4;
+        displayMode = DISPLAY_MODE_PAIRING;
         homeSelected = false;
         audioFeedback(AudioCue::Back);
       } else {
@@ -1132,41 +1157,42 @@ void loop() {
         const char* peerName = discovery.getPeerName(infoPeer);
         ModuleState* module = findModuleByName(peerName);
         setActiveModule(module);
-        if(module->descriptor->kind == PeerKind::Bulky){
+        if(module && module->descriptor->kind == PeerKind::Bulky){
           botMotionState = STOP;
           botSpeed = 0;
-        } else if(module->descriptor->kind == PeerKind::Thegill){
+        } else if(module && module->descriptor->kind == PeerKind::Thegill){
           resetThegillState();
           gillConfigIndex = 0;
         }
-        displayMode = 5;
+        displayMode = DISPLAY_MODE_DASHBOARD;
         dashboardFocusIndex = 0;
         audioFeedback(AudioCue::Select);
       }
-    } else if(displayMode == 2){
-      displayMode = 0;
+    } else if(displayMode == DISPLAY_MODE_PID){
+      displayMode = DISPLAY_MODE_HOME;
       homeMenuIndex = 2;
       audioFeedback(AudioCue::Back);
-    } else if(displayMode == 3 || displayMode == 6){
+    } else if(displayMode == DISPLAY_MODE_ORIENTATION || displayMode == DISPLAY_MODE_ABOUT){
       if(homeSelected){
-        displayMode = 0;
+        displayMode = DISPLAY_MODE_HOME;
         homeMenuIndex = 0;
         homeSelected = false;
         audioFeedback(AudioCue::Back);
       }
-    } else if(displayMode == 8){
-      const int baseCount = 6;
+    } else if(displayMode == DISPLAY_MODE_GLOBAL_MENU){
+      const int baseCount = 7;
       const int wifiEntryIndex = baseCount + 3;
       if(globalMenuIndex < baseCount){
         switch(globalMenuIndex){
-          case 0: displayMode = 5; break;
-          case 1: displayMode = 1; gillConfigIndex = 0; break;
-          case 2: displayMode = 2; break;
-          case 3: displayMode = 3; break;
-          case 4: displayMode = 4; break;
-          case 5: displayMode = 6; break;
+          case 0: displayMode = DISPLAY_MODE_DASHBOARD; break;
+          case 1: displayMode = DISPLAY_MODE_TELEMETRY; gillConfigIndex = 0; break;
+          case 2: displayMode = DISPLAY_MODE_PID; break;
+          case 3: displayMode = DISPLAY_MODE_ORIENTATION; break;
+          case 4: displayMode = DISPLAY_MODE_PAIRING; break;
+          case 5: displayMode = DISPLAY_MODE_LOG; logScrollOffset = 0; break;
+          case 6: displayMode = DISPLAY_MODE_ABOUT; break;
         }
-        if(displayMode == 4){
+        if(displayMode == DISPLAY_MODE_PAIRING){
           selectedPeer = 0;
         }
         homeSelected = false;
@@ -1182,9 +1208,14 @@ void loop() {
           toggleModuleWifi(*active);
         }
       } else {
-        displayMode = 5;
+        displayMode = DISPLAY_MODE_DASHBOARD;
         audioFeedback(AudioCue::Back);
       }
+    } else if(displayMode == DISPLAY_MODE_LOG){
+      displayMode = DISPLAY_MODE_PAIRING;
+      selectedPeer = 0;
+      lastDiscoveryTime = now;
+      audioFeedback(AudioCue::Select);
     }
     lastEncoderCount = encoderCount;
   }


### PR DESCRIPTION
## Summary
- add a reusable connection log buffer and show it as the default dashboard when no peers are paired
- expose the link log screen from the global menu with encoder scrolling and quick pairing access
- extend ESP-NOW discovery with command packets and log key pairing/command events for later customization

## Testing
- platformio run *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d3c2ff65bc832aa6e1d687824f9162