### PR TITLE
Make dashboard function bar encoder-friendly

### DIFF
--- a/include/ui_modules.h
+++ b/include/ui_modules.h
@@ -10,6 +10,8 @@ enum class PeerKind : uint8_t {
 
 struct ModuleState;
 
+constexpr size_t kMaxFunctionSlots = 3;
+
 struct FunctionActionOption {
   const char* name;
   const char* shortLabel;
@@ -31,8 +33,8 @@ struct ModuleDescriptor {
 struct ModuleState {
   const ModuleDescriptor* descriptor;
   bool wifiEnabled;
-  uint8_t assignedActions[3];
-  bool functionOutputs[3];
+  uint8_t assignedActions[kMaxFunctionSlots];
+  bool functionOutputs[kMaxFunctionSlots];
 };
 
 size_t getModuleStateCount();


### PR DESCRIPTION
## Summary
- add a configurable maximum function slot constant shared across modules and UI helpers
- redesign the dashboard function key bar with compact tiles, focus highlighting, and a hardware button state strip
- allow the encoder to scroll across each function slot and invoke actions without the physical buttons while keeping the menu counts consistent

## Testing
- platformio run *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68d3c8d50524832a92fc048c047dec55