### PR TITLE
Wrap connection log entries to display width

### DIFF
--- a/include/display.h
+++ b/include/display.h
@@ -82,6 +82,10 @@ void Pid_Tuner();
 void Fire_detection();
 void displayMenu();
 
+// Returns the maximum scroll offset for the connection log based on the
+// currently stored entries and display dimensions.
+int getLogMaxScrollOffset();
+
 // Utility helpers
 void drawHeader(const char* title);
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1079,11 +1079,7 @@ void loop() {
   } else if(displayMode == DISPLAY_MODE_LOG){
     size_t count = connectionLogGetCount();
     if(delta != 0 && count > 0){
-      int visibleLines = 6;
-      int maxOffset = 0;
-      if(count > static_cast<size_t>(visibleLines)){
-        maxOffset = static_cast<int>(count) - visibleLines;
-      }
+      int maxOffset = getLogMaxScrollOffset();
       logScrollOffset = constrain(logScrollOffset - delta, 0, maxOffset);
       lastEncoderCount = encoderCount;
       audioFeedback(AudioCue::Scroll);


### PR DESCRIPTION
## Summary
- wrap connection log entries to the display width and render wrapped segments sequentially
- expose a helper to compute the maximum log scroll offset so encoder scrolling matches the wrapped view

## Testing
- pio run *(fails: command not found: pio)*

------
https://chatgpt.com/codex/tasks/task_e_68d3e7a83224832aaf0706582e75d72c