### PR TITLE
Limit pair request broadcasts to pairing state

### DIFF
--- a/src/espnow_discovery.cpp
+++ b/src/espnow_discovery.cpp
@@ -1,6 +1,9 @@
 #include "espnow_discovery.h"
 #include "audio_feedback.h"
 #include "connection_log.h"
+#if DEVICE_ROLE == DEVICE_ROLE_CONTROLLER
+#include "display.h"
+#endif
 
 #include <cstdio>
 #include <cstring>
@@ -117,7 +120,11 @@ void EspNowDiscovery::discover() {
     pruneExpiredPeers(now);
 
 #if DEVICE_ROLE == DEVICE_ROLE_CONTROLLER
-    if (now - lastBroadcastMs >= BROADCAST_INTERVAL_MS) {
+    bool shouldBroadcast = !link.paired;
+    if (!shouldBroadcast) {
+        shouldBroadcast = (displayMode == DISPLAY_MODE_PAIRING);
+    }
+    if (shouldBroadcast && now - lastBroadcastMs >= BROADCAST_INTERVAL_MS) {
         sendPacket(MessageType::MSG_PAIR_REQ, kBroadcastMac);
         lastBroadcastMs = now;
     }


### PR DESCRIPTION
## Summary
- include the display state when building as a controller so discovery can check the active screen
- only broadcast ESP-NOW pair requests when unpaired or when the UI is showing the pairing screen

## Testing
- `pio run` *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d4251eee7c832aa19e11e4f42b0c11